### PR TITLE
Scope, token & pycti changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - CONNECTOR_ID=ChangeMe
       - CONNECTOR_TYPE=INTERNAL_ENRICHMENT
       - CONNECTOR_NAME=SophosLabs Intelix Lookup
-      - CONNECTOR_SCOPE=Url,IPv4-Addr,Domain,File,File-Sha256,Artifact,StixFile
+      - CONNECTOR_SCOPE=Url,IPv4-Addr,Domain-Name,File,File-Sha256,Artifact,StixFile
       - CONNECTOR_AUTO=true
       - CONNECTOR_CONFIDENCE_LEVEL=50
       - CONNECTOR_LOG_LEVEL=info

--- a/src/main.py
+++ b/src/main.py
@@ -40,6 +40,7 @@ class ConnectorStart:
         r = requests.post("https://api.labs.sophos.com/oauth2/token", headers=h, data=d)
         if r.ok:
             r = r.json()
+            self.expires_in = int(time.time()) + r["expires_in"]
             return r["access_token"]
         else:
             raise ValueError("Unable to authenticate with Intelix")
@@ -51,6 +52,8 @@ class ConnectorStart:
         observable_value = observable["observable_value"]
         observable_type = observable["entity_type"]
         self.helper.log_info(observable)
+        if int(time.time()) >= self.expires_in:
+            self.token = self._get_token()
         analysis = intelixlookup(
             self.token, observable_value, self.intelix_region_uri, observable_type
         )

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,2 @@
-pycti==5.4.0
+pycti==5.8.2
 validators==0.20.0


### PR DESCRIPTION
Ben,

Thanks for the updates. These changes are to change the Domain scope to Domain-Name in the docker-compose, token refresh on expiration and updated the pycti version.

FWIW, one thing I noticed with the StixFile scope is I was only seeing file path and I believe command line, so I removed it from our docker-compose. I'm not sure if that might be the same for others implementations.